### PR TITLE
Import patch to fix segfault when loading game from memory

### DIFF
--- a/depends/common/beetle-gba/0001-Fix-need_fullpath-value-in-libretro-API.patch
+++ b/depends/common/beetle-gba/0001-Fix-need_fullpath-value-in-libretro-API.patch
@@ -1,0 +1,29 @@
+From 497ce2d8f4e5b1bf314dcc25b50fe3eb03b4a226 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Wed, 4 Jul 2018 09:51:07 -0700
+Subject: [PATCH] Fix need_fullpath value in libretro API
+
+This core assumes a full path is provided and does not handle the NULL
+indicator properly:
+
+https://github.com/libretro/beetle-gba-libretro/blob/f41ee5c/libretro.cpp#L3794
+---
+ libretro.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libretro.cpp b/libretro.cpp
+index 85b0fc0..8327cb5 100644
+--- a/libretro.cpp
++++ b/libretro.cpp
+@@ -3960,7 +3960,7 @@ void retro_get_system_info(struct retro_system_info *info)
+ #define GIT_VERSION ""
+ #endif
+    info->library_version  = MEDNAFEN_CORE_VERSION GIT_VERSION;
+-   info->need_fullpath    = false;
++   info->need_fullpath    = true;
+    info->valid_extensions = MEDNAFEN_CORE_EXTENSIONS;
+    info->block_extract    = false;
+ }
+-- 
+2.7.4
+


### PR DESCRIPTION
This imports the change from https://github.com/libretro/beetle-gba-libretro/pull/33. It is a temporary measure until the ideas in https://github.com/libretro/libretro-common/issues/82 are implemented.